### PR TITLE
refactor: drop_constraint constraint_name needs to be optional op.pyi

### DIFF
--- a/alembic/op.pyi
+++ b/alembic/op.pyi
@@ -942,7 +942,7 @@ def drop_column(
     """
 
 def drop_constraint(
-    constraint_name: str,
+    constraint_name: Optional[str],
     table_name: str,
     type_: Optional[str] = None,
     *,


### PR DESCRIPTION
Alembic generates drop_constraint in migration files, sometimes with None as the `constraint_name`. The current type is `str`, but alembic still puts `None`. To stop Mypy from complaining, this parameter needs to be an optional.